### PR TITLE
Static server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 
 # Install vim and ssh
 RUN apt-get update
-RUN apt-get install vim openssh-client
+RUN apt-get install -y vim openssh-client
 
 WORKDIR /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ MAINTAINER Xaver Klemenschits <klemenschits@iue.tuwien.ac.at>
 
 USER root
 
+# Install vim and ssh
+RUN apt-get update
+RUN apt-get install vim openssh-client
+
 WORKDIR /tmp
 
 COPY ./ jupyter_c_kernel/

--- a/jupyter_c_kernel/kernel.py
+++ b/jupyter_c_kernel/kernel.py
@@ -102,6 +102,8 @@ class CKernel(Kernel):
     def __init__(self, *args, **kwargs):
         super(CKernel, self).__init__(*args, **kwargs)
         self._allow_stdin = True
+        self.readOnlyFileSystem = True
+        self.wErrorwAll = True
         self.files = []
         mastertemp = tempfile.mkstemp(suffix='.out')
         os.close(mastertemp[0])
@@ -145,6 +147,10 @@ class CKernel(Kernel):
 
     def compile_with_gcc(self, source_filename, binary_filename, cflags=None, ldflags=None):
         cflags = ['-std=c11', '-fPIC', '-shared', '-rdynamic'] + cflags
+        if self.wErrorwAll:
+            cflags = cflags + ['-Wall', '-Werror']
+        if self.readOnlyFileSystem:
+            cflags = ['-DREAD_ONLY_FILE_SYSTEM'] + cflags
         args = ['gcc', source_filename] + cflags + ['-o', binary_filename] + ldflags
         return self.create_jupyter_subprocess(args)
 
@@ -178,8 +184,13 @@ class CKernel(Kernel):
     # check whether int main() is specified, if not add it around the code
     # also add common magics like -lm
     def _add_main(self, magics, code):
-        x = re.search("int\s+main\s*\(", code)
-        if x is None:
+        # remove comments
+        tmpCode = re.sub("//.*", "", code)
+        tmpCode = re.sub("/\*.*?\*/", "", tmpCode, flags=re.M|re.S)
+
+        x = re.search("int\s+main\s*\(", tmpCode)
+
+        if not x:
             code = self.main_head + code + self.main_foot
             magics['cflags'] += ['-lm']
 

--- a/jupyter_c_kernel/kernel.py
+++ b/jupyter_c_kernel/kernel.py
@@ -102,8 +102,9 @@ class CKernel(Kernel):
     def __init__(self, *args, **kwargs):
         super(CKernel, self).__init__(*args, **kwargs)
         self._allow_stdin = True
-        self.readOnlyFileSystem = True
-        self.wErrorwAll = True
+        self.readOnlyFileSystem = False
+        self.wAll = True # show all warnings by default
+        self.wError = False # but keep comipiling for warnings
         self.files = []
         mastertemp = tempfile.mkstemp(suffix='.out')
         os.close(mastertemp[0])
@@ -147,8 +148,10 @@ class CKernel(Kernel):
 
     def compile_with_gcc(self, source_filename, binary_filename, cflags=None, ldflags=None):
         cflags = ['-std=c11', '-fPIC', '-shared', '-rdynamic'] + cflags
-        if self.wErrorwAll:
-            cflags = cflags + ['-Wall', '-Werror']
+        if self.wError:
+            cflags = cflags + ['-Werror']
+        if self.wAll:
+            cflags = cflags + ['-Wall']
         if self.readOnlyFileSystem:
             cflags = ['-DREAD_ONLY_FILE_SYSTEM'] + cflags
         args = ['gcc', source_filename] + cflags + ['-o', binary_filename] + ldflags

--- a/jupyter_c_kernel/resources/stdio_wrap.h
+++ b/jupyter_c_kernel/resources/stdio_wrap.h
@@ -1,10 +1,59 @@
+#ifndef STDIO_WRAP_H
+#define STDIO_WRAP_H
+
 #include <stdio.h>
+#include <stdarg.h>
+
+/* Define the functions to overload the old ones */
+int scanf_wrap(const char *format, ...) {
+  printf("<inputRequest>");
+  fflush(stdout);
+  va_list arglist;
+  va_start( arglist, format );
+  int result = vscanf( format, arglist );
+  va_end( arglist );
+  return result;
+}
+
+int getchar_wrap(){
+  printf("<inputRequest>");
+  fflush(stdout);
+  return getchar();
+}
 
 /* Replace all the necessary input functions */
-#define scanf(...) printf("<inputRequest>");\
-fflush(stdout);\
-scanf(__VA_ARGS__);
+#define scanf(format, ...) scanf_wrap(format, __VA_ARGS__)
 
-#define getchar() printf("<inputRequest>");\
-fflush(stdout);\
-getchar();
+#define getchar() getchar_wrap()
+
+/* Replace FILE write operations for read-only systems */
+#ifdef READ_ONLY_FILE_SYSTEM
+
+/* Define wrapping functions */
+/* Output that the fopen succeeded and return some valid pointer */
+FILE *fopen_wrap(const char *filename, const char *modes) {
+  static long stream = 0x1FFFF0000;
+#ifdef SHOW_FILE_IO_VERBOSE
+  printf("\"%s\" opened in mode \"%s\"\n", filename, modes);
+#endif /* SHOW_FILE_IO_VERBOSE */
+  return (FILE*)stream++;
+}
+
+int fprintf_wrap(FILE* stream, const char* format, ...) {
+  printf("\x01b[42m");
+  va_list arglist;
+  va_start( arglist, format );
+  int result = vprintf(format, arglist);
+  va_end( arglist );
+  printf("\x01b[0m");
+  return result;
+}
+
+/* Replace all the necessary input functions */
+#define fopen(file, mode) fopen_wrap(file, mode)
+
+#define fprintf(stream, format, ...) fprintf_wrap(stream, format, __VA_ARGS__)
+
+#endif  /* READ_ONLY_FILE_SYSTEM */
+
+#endif /* STDIO_WRAP_H */

--- a/jupyter_c_kernel/resources/stdio_wrap.h
+++ b/jupyter_c_kernel/resources/stdio_wrap.h
@@ -21,8 +21,9 @@ int getchar_wrap(){
   return getchar();
 }
 
-/* Replace all the necessary input functions */
-#define scanf(format, ...) scanf_wrap(format, __VA_ARGS__)
+/* Replace all the necessary input functions
+  Need double hashes in case there are no __VA_ARGS__*/
+#define scanf(format, ...) scanf_wrap(format, ##__VA_ARGS__)
 
 #define getchar() getchar_wrap()
 
@@ -34,25 +35,28 @@ int getchar_wrap(){
 FILE *fopen_wrap(const char *filename, const char *modes) {
   static long stream = 0x1FFFF0000;
 #ifdef SHOW_FILE_IO_VERBOSE
+  printf("\x01b[42m");
   printf("\"%s\" opened in mode \"%s\"\n", filename, modes);
+  printf("\x01b[0m");
 #endif /* SHOW_FILE_IO_VERBOSE */
   return (FILE*)stream++;
 }
 
 int fprintf_wrap(FILE* stream, const char* format, ...) {
   printf("\x01b[42m");
+  printf("%p:", stream);
+  printf("\x01b[0m");
   va_list arglist;
   va_start( arglist, format );
   int result = vprintf(format, arglist);
   va_end( arglist );
-  printf("\x01b[0m");
   return result;
 }
 
 /* Replace all the necessary input functions */
 #define fopen(file, mode) fopen_wrap(file, mode)
 
-#define fprintf(stream, format, ...) fprintf_wrap(stream, format, __VA_ARGS__)
+#define fprintf(stream, format, ...) fprintf_wrap(stream, format, ##__VA_ARGS__)
 
 #endif  /* READ_ONLY_FILE_SYSTEM */
 


### PR DESCRIPTION
* Added overloads for file writing if on a ro file system. Write operations will be preprenden with the filepointer with green background. Off by default, can be enabled defining READ_ONLY_FILE_SYSTEM. In Notebook: //%cflags:-DREAD_ONLY_FILE_SYSTEM

* fixed docker build halt by adding -y

* Fixed no var args error for I/O overloads