### PR TITLE
Fix language info name.

### DIFF
--- a/jupyter_c_kernel/kernel.py
+++ b/jupyter_c_kernel/kernel.py
@@ -90,7 +90,7 @@ class CKernel(Kernel):
     implementation_version = '1.0'
     language = 'c'
     language_version = 'C11'
-    language_info = {'name': 'text/x-csrc',
+    language_info = {'name': 'c',
                      'mimetype': 'text/x-csrc',
                      'file_extension': '.c'}
     banner = "C kernel.\n" \


### PR DESCRIPTION
Hi, thanks for maintaining this fork of jupyter-c-kernel.

After changing to this version, there was an issue where Jupyter's syntax highlighting stopped working.

It seems that the language name should be c, not the mime type of text/x-csrc. 

I have tested that this solves the syntax highlighting problem.
(running jupyter_client: 8.6.1, jupyter_core: 5.7.2, jupyter_server: 2.13.0)

Hope this helps!
